### PR TITLE
Make it thread-safe

### DIFF
--- a/src/rc4ok.rs
+++ b/src/rc4ok.rs
@@ -1,12 +1,14 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
 /// RC4OK is a lightweight high-performance cryptographically strong random
-/// number generator based on an improved variant of RC4 stream cipher.
+/// number generator based on an improved variant of RC4 stream cipher such
+/// that adding entropy to the state is low-overhead and thread-safe.
 ///
 /// Note, classic RC4 is considered deprecated. The improved RC4OK scheme is proposed in https://ia.cr/2023/1486.
 /// This implementation collects inspiration from reference implementation https://github.com/emercoin/rc4ok/blob/09f0724f/rc4ok.c.
-#[derive(Copy, Clone)]
 pub struct RC4ok {
     s: [u8; 256],
-    j: u32,
+    j: AtomicU32,
     i: u8,
 }
 
@@ -20,7 +22,7 @@ impl RC4ok {
 
         let mut state = Self {
             s: [0u8; 256],
-            j: 0,
+            j: AtomicU32::new(0),
             i: 0,
         };
         state.ksa(key);
@@ -34,8 +36,13 @@ impl RC4ok {
         state
     }
 
-    /// Generates `n` random bytes using the modified RC4 stream cipher,
+    /// Generates `n` (>=0) pseudo-random bytes using the modified RC4 stream cipher,
     /// following description on page 4 of https://ia.cr/2023/1486.
+    ///
+    /// **Note**
+    /// You should be able to call this function from one thread (i.e. random number generator thread)
+    /// while another thread can continue adding entropy into the state of the RC4OK stream cipher,
+    /// in thread-safe manner.
     #[inline(always)]
     pub fn generate(&mut self, out: &mut [u8]) {
         self.prga(out);
@@ -43,19 +50,29 @@ impl RC4ok {
 
     /// Adds `16` -bit entropy into the internal state of the modified RC4 stream cipher,
     /// following description on page 5 of https://ia.cr/2023/1486.
+    ///
+    /// **Note**
+    /// You should be able to add entropy into the state of the RC4OK stream cipher from one
+    /// thread and another thread can continue generating pseudo-random bytes from RC4OK object.
     #[inline(always)]
     pub fn add_entropy(&mut self, entropy: u16) {
-        let mut jw1 = (self.j >> 16) as u16;
+        let mut atmc_j = self.j.load(Ordering::Acquire);
+        let mut atmc_jw1 = (atmc_j >> 16) as u16;
 
-        jw1 = jw1.rotate_left(1);
-        jw1 = jw1.wrapping_add(entropy);
+        atmc_jw1 = atmc_jw1.rotate_left(1);
+        atmc_jw1 = atmc_jw1.wrapping_add(entropy);
 
         const MASK: u32 = 0x0000ffff;
-        self.j = (self.j & MASK) | ((jw1 as u32) << 16);
+        atmc_j = (atmc_j & MASK) | ((atmc_jw1 as u32) << 16);
+        self.j.store(atmc_j, Ordering::Release);
     }
 
     /// Given already initialized (and probably used too) RC4OK stream cipher object,
-    /// this routine can be invoked for reinitializing it with different key.
+    /// this routine can be invoked for reinitializing it with a different key.
+    ///
+    /// **Note**
+    /// This is **NOT** thread-safe to invoke this function from one thread while another
+    /// thread is either adding entropy into the state or generating pseudo-random bytes.
     #[inline(always)]
     pub fn reset(&mut self, key: &[u8]) {
         debug_assert!(key.len() > 0, "Key must be non-empty !");
@@ -111,7 +128,7 @@ impl RC4ok {
         }
 
         self.i = self.s[j ^ 85];
-        self.j = 0;
+        self.j.store(0, Ordering::Release);
     }
 
     /// Pseudo Random Generation Algorithm
@@ -127,9 +144,11 @@ impl RC4ok {
             self.i = self.i.wrapping_add(11);
             let mut a = self.s[self.i as usize];
 
-            self.j = self.j.rotate_left(1).wrapping_add(a as u32);
+            let mut atmc_j = self.j.load(Ordering::Acquire);
+            atmc_j = atmc_j.rotate_left(1).wrapping_add(a as u32);
+            self.j.store(atmc_j, Ordering::Release);
 
-            let j0 = self.j as u8;
+            let j0 = atmc_j as u8;
             let mut b = self.s[j0 as usize];
 
             // swap(self.s[self.i], self.s[j0])

--- a/src/test_rc4ok.rs
+++ b/src/test_rc4ok.rs
@@ -35,6 +35,7 @@ fn test_known_answer_tests() {
     }
 }
 
+#[cfg(debug_assertions)]
 #[test]
 #[should_panic(expected = "Key must be non-empty !")]
 fn test_failure_with_empty_key() {


### PR DESCRIPTION
Make 
(i)  generation of pseudo-random bytes
(ii) addition of entropy to the RC4OK state
thread-safe, using atomic operation.